### PR TITLE
release/0.0.1-nullsafety.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fix: The package description is too short.
 - fix: The value of the local variable 'onOpenSubcription' isn't used (api_client).
+- fix: cancel subscribe warning.
 
 # 0.0.1-nullsafety.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat: test for jwt util
 - feat: type definitions test
 - fix: payload type conversion
+- fix: typing for uhst host create
 
 # 0.0.1-nullsafety.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.1-nullsafety.1
+
+- fix: The package description is too short.
+- fix: The value of the local variable 'onOpenSubcription' isn't used (api_client).
+
 # 0.0.1-nullsafety.0
 
 - Initial development release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: The package description is too short.
 - fix: The value of the local variable 'onOpenSubcription' isn't used (api_client).
 - fix: cancel subscribe warning.
+- feat: test for jwt util
 
 # 0.0.1-nullsafety.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - fix: The value of the local variable 'onOpenSubcription' isn't used (api_client).
 - fix: cancel subscribe warning.
 - feat: test for jwt util
+- feat: type definitions test
+- fix: payload type conversion
 
 # 0.0.1-nullsafety.0
 

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -6,23 +6,23 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 // import 'package:example/main.dart';
-import 'package:flutter_test/flutter_test.dart';
+// import 'package:test/test.dart';
 
-void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    // await tester.pumpWidget(MyApp());
+// void main() {
+//   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+//     // Build our app and trigger a frame.
+//     // await tester.pumpWidget(MyApp());
 
-    // // Verify that our counter starts at 0.
-    // expect(find.text('0'), findsOneWidget);
-    // expect(find.text('1'), findsNothing);
+//     // // Verify that our counter starts at 0.
+//     // expect(find.text('0'), findsOneWidget);
+//     // expect(find.text('1'), findsNothing);
 
-    // // Tap the '+' icon and trigger a frame.
-    // await tester.tap(find.byIcon(Icons.add));
-    // await tester.pump();
+//     // // Tap the '+' icon and trigger a frame.
+//     // await tester.tap(find.byIcon(Icons.add));
+//     // await tester.pump();
 
-    // // Verify that our counter has incremented.
-    // expect(find.text('0'), findsNothing);
-    // expect(find.text('1'), findsOneWidget);
-  });
-}
+//     // // Verify that our counter has incremented.
+//     // expect(find.text('0'), findsNothing);
+//     // expect(find.text('1'), findsOneWidget);
+//   });
+// }

--- a/lib/src/api_clients/api_client.dart
+++ b/lib/src/api_clients/api_client.dart
@@ -123,11 +123,11 @@ class ApiClient implements UhstApiClient {
     var uri = Uri.parse(finalUrl);
 
     EventSource source = EventSource(finalUrl);
-    var onOpenSubcription = source.onOpen.listen((event) {});
-    var onErrorSubcription = source.onError.listen((event) {
+    source.onOpen.listen((event) {});
+    source.onError.listen((event) {
       throw ApiError(uri);
     });
-    var onMessageSubcription = source.onMessage.listen((event) {
+    source.onMessage.listen((event) {
       var eventMessageMap = jsonDecode(event.data);
       var eventMessage = EventMessage.fromJson(eventMessageMap);
       handler(message: eventMessage.body);

--- a/lib/src/contracts/type_definitions.dart
+++ b/lib/src/contracts/type_definitions.dart
@@ -35,9 +35,9 @@ extension PayloadTypeDescribe on PayloadType {
           case 'blob':
             return PayloadType.blob;
           case 'byteBuffer':
-            return PayloadType.blob;
+            return PayloadType.byteBuffer;
           case 'typedData':
-            return PayloadType.blob;
+            return PayloadType.typedData;
           default:
             throw RangeError("enum PayloadType contains no value '$name'");
         }

--- a/lib/src/hosts/host_subscriptions.dart
+++ b/lib/src/hosts/host_subscriptions.dart
@@ -81,6 +81,7 @@ mixin HostSubsriptions implements UhstHostSocket {
   }
 
   void onceConnection({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onConnection(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(HostEventType.connection))
@@ -89,6 +90,7 @@ mixin HostSubsriptions implements UhstHostSocket {
   }
 
   void onceDiagnostic({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onDiagnostic(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(HostEventType.diagnostic))
@@ -97,6 +99,7 @@ mixin HostSubsriptions implements UhstHostSocket {
   }
 
   void onceError({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onError(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(HostEventType.error)) offError(handler: handler);
@@ -104,6 +107,7 @@ mixin HostSubsriptions implements UhstHostSocket {
   }
 
   void onceReady({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onReady(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(HostEventType.ready)) offReady(handler: handler);

--- a/lib/src/hosts/uhst_host.dart
+++ b/lib/src/hosts/uhst_host.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:uhst/src/contracts/uhst_api_client.dart';
 import 'package:universal_html/html.dart';
 
 import '../contracts/type_definitions.dart';
@@ -104,8 +105,8 @@ class UhstHost with HostSubsriptions implements UhstHostSocket {
   ///
   /// [hostId] can be null and will be returned with `onReady` event
   static UhstHost create(
-      {required apiClient,
-      required socketProvider,
+      {required UhstApiClient apiClient,
+      required UhstSocketProvider socketProvider,
       String? hostId,
       required debug}) {
     // Call the private constructor

--- a/lib/src/models/event_message.dart
+++ b/lib/src/models/event_message.dart
@@ -6,7 +6,7 @@ class EventMessage {
 
   EventMessage({required this.body, required this.responseToken});
 
-  static EventMessage fromJson(Map<dynamic, dynamic> map) {
+  factory EventMessage.fromJson(Map<dynamic, dynamic> map) {
     var message = Message.fromJson(map['body']);
     var responseToken = map['responseToken'] ?? '';
     message.responseToken = responseToken;

--- a/lib/src/models/message.dart
+++ b/lib/src/models/message.dart
@@ -12,7 +12,7 @@ class Message {
       required this.payload,
       this.isBroadcast,
       this.responseToken});
-  static Message fromJson(Map<dynamic, dynamic> map) {
+  factory Message.fromJson(Map<dynamic, dynamic> map) {
     PayloadType verifiedPayloadType = (() {
       String? _payloadType = map['type'];
       if (_payloadType == null || _payloadType.isEmpty)

--- a/lib/src/sockets/relay_socket.dart
+++ b/lib/src/sockets/relay_socket.dart
@@ -116,7 +116,7 @@ class RelaySocket with SocketSubsriptions implements UhstSocket {
 
       h.token = config.clientToken;
       h.sendUrl = config.sendUrl;
-      h.apiMessageStream = await h.apiClient.subscribeToMessages(
+      h.apiMessageStream = h.apiClient.subscribeToMessages(
           token: config.clientToken,
           handler: handleMessage,
           receiveUrl: config.receiveUrl);

--- a/lib/src/sockets/socket_subsriptions.dart
+++ b/lib/src/sockets/socket_subsriptions.dart
@@ -97,6 +97,7 @@ mixin SocketSubsriptions implements UhstSocket {
   }
 
   void onceClose({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onClose(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(UhstSocketEventType.close))
@@ -105,6 +106,7 @@ mixin SocketSubsriptions implements UhstSocket {
   }
 
   void onceDiagnostic({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onDiagnostic(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(UhstSocketEventType.diagnostic))
@@ -113,6 +115,7 @@ mixin SocketSubsriptions implements UhstSocket {
   }
 
   void onceError({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onError(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(UhstSocketEventType.error))
@@ -121,6 +124,7 @@ mixin SocketSubsriptions implements UhstSocket {
   }
 
   void onceMessage({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onMessage(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(UhstSocketEventType.message))
@@ -129,6 +133,7 @@ mixin SocketSubsriptions implements UhstSocket {
   }
 
   void onceOpen({required handler}) {
+    // ignore: cancel_subscriptions
     var subscription = onOpen(handler: handler);
     subscription.onData((data) {
       if (data.containsKey(UhstSocketEventType.open)) offOpen(handler: handler);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,15 @@
 name: uhst
-version: 0.0.1-nullsafety.0
+version: 0.0.1-nullsafety.1
 
 description: >-
-  User Hosted Secure Transmission (uhst) 
-  for Flutter in Dart
+  User Hosted Secure Transmission (uhst) for to:
+  - send messages from client and listen messages broadcasted from host
+  - broadcast messages by host
+  - listen messages from multiple clients by host
+
 homepage: https://github.com/uhst/uhst-client-flutter
 environment:
-  sdk: ">=2.12.0-133.7.beta <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/src/contracts/type_definitions_test.dart
+++ b/test/src/contracts/type_definitions_test.dart
@@ -1,0 +1,30 @@
+import 'package:test/test.dart';
+import 'package:uhst/src/contracts/type_definitions.dart';
+
+const stringTypes = ['string', 'blob', 'typedData', 'byteBuffer'];
+const payloadTypes = [
+  PayloadType.string,
+  PayloadType.blob,
+  PayloadType.typedData,
+  PayloadType.byteBuffer
+];
+
+void main() {
+  group('# type definitions', () {
+    test('get string from payload type', () {
+      var result = <String>[];
+      payloadTypes.forEach((type) {
+        result.add(type.toStringValue());
+      });
+
+      expect(result, equals(stringTypes));
+    });
+    test('get payload type from string', () {
+      var result = <PayloadType>[];
+      stringTypes.forEach((type) {
+        result.add(PayloadType.fromString[type]);
+      });
+      expect(result, equals(payloadTypes));
+    });
+  });
+}

--- a/test/src/hosts/host_test.dart
+++ b/test/src/hosts/host_test.dart
@@ -1,0 +1,34 @@
+// import 'package:test/test.dart';
+// import 'package:uhst/src/contracts/uhst_api_client.dart';
+// import 'package:uhst/src/contracts/uhst_host_event.dart';
+// import 'package:uhst/src/contracts/uhst_socket_provider.dart';
+// import 'package:uhst/uhst.dart';
+
+// var host = UhstHost.create(
+//     apiClient: {} as UhstApiClient,
+//     socketProvider: {} as UhstSocketProvider,
+//     debug: false);
+
+// /// FIXME: This test is not working:(
+// /// somehow there is an error with loading uhst_host
+// /// It is not connected with universal_html
+// /// (after reomval there is still no result)
+// /// and need to be investigated
+// void main() {
+//   group('# host', () {
+//     test('init host', () {
+//       // expect(host.h.eventStream, isNotNull);
+//       // expect(host.h.eventStreamController, isNotNull);
+//       // expect(host.h.debug, equals(false));
+//       // expect(host.h.apiClient, isNotNull);
+//     });
+//     test('send and catch message inside event stream', () {
+//       // var message = 'testMessage';
+//       var messageType = HostEventType.ready;
+//       // host.h.emit(message: HostEventType.ready, body: message);
+//       // host.h.eventStream.listen((event) {
+//       //   expect(event.entries, equals({messageType: message}));
+//       // });
+//     });
+//   });
+// }

--- a/test/src/utils/jwt_test.dart
+++ b/test/src/utils/jwt_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/test.dart';
+import 'package:uhst/src/utils/jwt.dart';
+
+const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiY2xpZW50SWQiOiJ0ZXN0SWQiLCJpYXQiOjE1MTYyMzkwMjJ9.x8ZFLkeSZENZGTowMW_LWGlyGwBlL-zelVbOn0UCygk';
+
+void main() {
+  group('# jwt', () {
+    test('decode body', () {
+      var result = Jwt.decode(token: token);
+      var expectResult = {
+        "sub": "1234567890",
+        "clientId": "testId",
+        "iat": 1516239022
+      };
+      expect(result, equals(expectResult));
+    });
+    test('get [clientId]', () {
+      var result = Jwt.decodeSubject(token: token);
+      expect(result, equals('testId'));
+    });
+  });
+}


### PR DESCRIPTION
- fix: The package description is too short.
- fix: The value of the local variable 'onOpenSubcription' isn't used (api_client).
- fix: cancel subscribe warning.
- feat: test for jwt util
- feat: type definitions test
- fix: payload type conversion
- fix: typing for uhst host create

perf: is not possible to setup tests for hosts - it fails to load any classes:(